### PR TITLE
Fix unaligned access on armhf in engine/client/gl_sprite.c

### DIFF
--- a/engine/client/gl_sprite.c
+++ b/engine/client/gl_sprite.c
@@ -97,10 +97,21 @@ static dframetype_t *R_SpriteLoadFrame( model_t *mod, void *pin, mspriteframe_t 
 	pspriteframe = Mem_Alloc( mod->mempool, sizeof( mspriteframe_t ));
 	pspriteframe->width = pinframe->width;
 	pspriteframe->height = pinframe->height;
+	#ifdef __VFP_FP__
+	float tmp,tmp2;
+	memcpy( &pspriteframe->up, pinframe->origin+1, 4 );
+	memcpy( &pspriteframe->left, pinframe->origin,4 );
+	memcpy( &tmp2, pinframe->origin+1, 4 );
+	memcpy( &tmp, &pinframe->height, 4 );
+	pspriteframe->down = tmp2 - tmp;
+	tmp = pinframe->width + *( pinframe->origin );
+	pspriteframe->right = tmp;
+        #else
 	pspriteframe->up = pinframe->origin[1];
 	pspriteframe->left = pinframe->origin[0];
 	pspriteframe->down = pinframe->origin[1] - pinframe->height;
 	pspriteframe->right = pinframe->width + pinframe->origin[0];
+	#endif
 	pspriteframe->gl_texturenum = gl_texturenum;
 	*ppframe = pspriteframe;
 


### PR DESCRIPTION
It seems to work fine with gcc 4.8