### PR TITLE
Remove unnecessary EGL attributes to avoid sw render

### DIFF
--- a/engine/client/gl_vidnt.c
+++ b/engine/client/gl_vidnt.c
@@ -954,10 +954,7 @@ void GL_SetupAttributes()
 	SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
 
 
-	SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+	SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 8);
 
 #ifdef __ANDROID__
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);


### PR DESCRIPTION
Bad config choose algorithm in SDL causes using Android Pixelflinger on some devices.