### PR TITLE
SDL window events patch

### DIFF
--- a/engine/client/cl_main.c
+++ b/engine/client/cl_main.c
@@ -1755,8 +1755,6 @@ void Host_ClientFrame( void )
 		menu.globals->demorecording = cls.demorecording;
 	}
 
-	// if in the debugger last frame, don't timeout
-	if( host.frametime > 5.0f ) cls.netchan.last_received = Sys_DoubleTime();
 #ifdef XASH_VGUI
 	VGui_RunFrame ();
 #endif

--- a/engine/client/cl_menu.c
+++ b/engine/client/cl_menu.c
@@ -886,13 +886,6 @@ pfnStartBackgroundTrack
 static void pfnStartBackgroundTrack( const char *introTrack, const char *mainTrack )
 {
 	S_StartBackgroundTrack( introTrack, mainTrack, 0 );
-
-	// HACKHACK to remove glitches from background track while new game is started.
-	if( !introTrack && !mainTrack )
-	{
-		S_Activate( 0, host.hWnd );
-		S_Activate( 1, host.hWnd );
-	}
 }
 
 #ifndef XASH_SDL

--- a/engine/client/gl_vidnt.c
+++ b/engine/client/gl_vidnt.c
@@ -1524,8 +1524,8 @@ qboolean VID_CreateWindow( int width, int height, qboolean fullscreen )
 		wndFlags |= SDL_WINDOW_FULLSCREEN;
 	}
 
-	host.hWnd = SDL_CreateWindow(wndname, SDL_WINDOWPOS_UNDEFINED,
-		SDL_WINDOWPOS_UNDEFINED, width, height, wndFlags);
+	host.hWnd = SDL_CreateWindow(wndname, r_xpos->integer,
+		r_ypos->integer, width, height, wndFlags);
 
 	// host.hWnd must be filled in IN_WndProc
 	if( !host.hWnd )

--- a/engine/client/s_backend.c
+++ b/engine/client/s_backend.c
@@ -32,7 +32,6 @@ so it can unlock and free the data block after it has been played.
 convar_t		*s_primary;
 convar_t		*s_khz;
 dma_t			dma;
-int				shutdown_temp = 0;
 
 static qboolean	snd_firsttime = true;
 static qboolean	primary_format_set;
@@ -248,18 +247,4 @@ void S_PrintDeviceName( void )
 #ifdef XASH_SDL
 	Msg( "Audio: SDL (driver: %s)\n", SDL_GetCurrentAudioDriver() );
 #endif
-}
-
-/*
-===========
-S_Activate
-
-Called when the main window gains or loses focus.
-The window have been destroyed and recreated
-between a deactivate and an activate.
-===========
-*/
-void S_Activate( qboolean active, void *hInst )
-{
-	shutdown_temp = active;
 }

--- a/engine/client/s_main.c
+++ b/engine/client/s_main.c
@@ -49,6 +49,7 @@ convar_t		*snd_foliage_db_loss;
 convar_t		*snd_gain;
 convar_t		*snd_gain_max;
 convar_t		*snd_gain_min;
+convar_t		*snd_mute_losefocus;
 convar_t		*s_refdist;
 convar_t		*s_refdb;
 convar_t		*dsp_off;		// set to 1 to disable all dsp processing
@@ -1780,6 +1781,7 @@ qboolean S_Init( void )
 	snd_foliage_db_loss = Cvar_Get( "snd_foliage_db_loss", "4", 0, "foliage loss factor" ); 
 	snd_gain_max = Cvar_Get( "snd_gain_max", "1", 0, "gain maximal threshold" );
 	snd_gain_min = Cvar_Get( "snd_gain_min", "0.01", 0, "gain minimal threshold" );
+	snd_mute_losefocus = Cvar_Get( "snd_mute_losefocus", "1", CVAR_ARCHIVE, "silence the audio when game window loses focus" );
 	s_refdist = Cvar_Get( "s_refdist", "36", 0, "soundlevel reference distance" );
 	s_refdb = Cvar_Get( "s_refdb", "60", 0, "soundlevel refernce dB" );
 	snd_gain = Cvar_Get( "snd_gain", "1", 0, "sound default gain" );
@@ -1830,6 +1832,7 @@ void S_Shutdown( void )
 	if( !dma.initialized ) return;
 
 	Cmd_RemoveCommand( "play" );
+	Cmd_RemoveCommand( "playvol" );
 	Cmd_RemoveCommand( "stopsound" );
 	Cmd_RemoveCommand( "music" );
 	Cmd_RemoveCommand( "soundlist" );

--- a/engine/client/sound.h
+++ b/engine/client/sound.h
@@ -297,7 +297,6 @@ void DSP_ClearState( void );
 
 qboolean S_Init( void );
 void S_Shutdown( void );
-void S_Activate( qboolean active, void *hInst );
 void S_SoundList_f( void );
 void S_SoundInfo_f( void );
 

--- a/engine/common/common.h
+++ b/engine/common/common.h
@@ -932,7 +932,6 @@ extern const char *svc_strings[256];
 // soundlib shared exports
 qboolean S_Init( void );
 void S_Shutdown( void );
-void S_Activate( qboolean active, void *hInst );
 void S_StopSound( int entnum, int channel, const char *soundname );
 int S_GetCurrentStaticSounds( soundlist_t *pout, int size );
 void S_StopAllSounds( void );

--- a/engine/common/input.c
+++ b/engine/common/input.c
@@ -40,7 +40,7 @@ RECT	window_rect, real_rect;
 #endif
 uint	in_mouse_wheel;
 int	wnd_caption;
-convar_t *fullscreen = 0;
+extern convar_t *vid_fullscreen;
 #ifdef PANDORA
 int noshouldermb = 0;
 #endif
@@ -253,7 +253,6 @@ void IN_StartupMouse( void )
 
 	in_mouse_buttons = 8;
 	in_mouseinitialized = true;
-	fullscreen = Cvar_FindVar( "fullscreen" );
 
 #ifdef _WIN32
 	in_mouse_wheel = RegisterWindowMessage( "MSWHEEL_ROLLMSG" );
@@ -362,7 +361,7 @@ void IN_ActivateMouse( qboolean force )
 		else
 #endif
 
-	if( cls.key_dest == key_menu && fullscreen && !fullscreen->integer)
+	if( cls.key_dest == key_menu && vid_fullscreen && !vid_fullscreen->integer)
 	{
 		// check for mouse leave-entering
 		if( !in_mouse_suspended && !UI_MouseInRect( ))
@@ -839,7 +838,7 @@ void Host_InputFrame( void )
 	if( cl.refdef.paused && cls.key_dest == key_game )
 		shutdownMouse = true; // release mouse during pause or console typeing
 	
-	if( shutdownMouse && !fullscreen->integer )
+	if( shutdownMouse && !vid_fullscreen->integer )
 	{
 		IN_DeactivateMouse();
 		return;

--- a/engine/common/keys.c
+++ b/engine/common/keys.c
@@ -652,14 +652,15 @@ void Key_Event( int key, qboolean down )
 	// distribute the key down event to the apropriate handler
 	if( cls.key_dest == key_game )
 	{
-		if(host.mouse_visible)
-			return;
-		if( cls.state == ca_cinematic && ( key != K_ESCAPE || !down ))
+		if( cls.state == ca_cinematic )
 		{
 			// only escape passed when cinematic is playing
 			// HLFX 0.6 bug: crash in vgui3.dll while press +attack during movie playback
-			return;
+			if( key != K_ESCAPE || !down )
+				return;
 		}
+		else if( host.mouse_visible )
+			return;
 
 		// send the bound action
 		kb = keys[key].binding;

--- a/engine/common/sdl/events.h
+++ b/engine/common/sdl/events.h
@@ -4,7 +4,7 @@
 #include <SDL_events.h>
 #include "common.h"
 
-int SDLash_EventFilter(SDL_Event* event);
+void SDLash_EventFilter(SDL_Event* event);
 void SDLash_KeyEvent(SDL_KeyboardEvent key);
 void SDLash_MouseEvent(SDL_MouseButtonEvent button);
 void SDLash_WheelEvent(SDL_MouseWheelEvent wheel);

--- a/mainui/menu_audio.cpp
+++ b/mainui/menu_audio.cpp
@@ -33,7 +33,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define ID_MUSICVOLUME		5
 #define ID_INTERP			6
 #define ID_NODSP			7
-#define ID_MSGHINT			8
+#define ID_MUTEFOCUSLOST	8
+#define ID_MSGHINT			9
 
 typedef struct
 {
@@ -58,6 +59,7 @@ typedef struct
 	menuSlider_s	suitVolume;
 	menuCheckBox_s	lerping;
 	menuCheckBox_s	noDSP;
+	menuCheckBox_s	muteFocusLost;
 } uiAudio_t;
 
 static uiAudio_t		uiAudio;
@@ -79,6 +81,9 @@ static void UI_Audio_GetConfig( void )
 	if( CVAR_GET_FLOAT( "dsp_off" ))
 		uiAudio.noDSP.enabled = 1;
 
+	if( CVAR_GET_FLOAT("snd_mute_losefocus" ))
+		uiAudio.muteFocusLost.enabled = 1;
+
 	// save initial values
 	uiAudioInitial.soundVolume = uiAudio.soundVolume.curValue;
 	uiAudioInitial.musicVolume = uiAudio.musicVolume.curValue;
@@ -97,6 +102,7 @@ static void UI_Audio_SetConfig( void )
 	CVAR_SET_FLOAT( "suitvolume", uiAudio.suitVolume.curValue );
 	CVAR_SET_FLOAT( "s_lerping", uiAudio.lerping.enabled );
 	CVAR_SET_FLOAT( "dsp_off", uiAudio.noDSP.enabled );
+	CVAR_SET_FLOAT( "snd_mute_losefocus", uiAudio.muteFocusLost.enabled );
 }
 
 /*
@@ -111,6 +117,7 @@ static void UI_Audio_UpdateConfig( void )
 	CVAR_SET_FLOAT( "suitvolume", uiAudio.suitVolume.curValue );
 	CVAR_SET_FLOAT( "s_lerping", uiAudio.lerping.enabled );
 	CVAR_SET_FLOAT( "dsp_off", uiAudio.noDSP.enabled );
+	CVAR_SET_FLOAT( "snd_mute_losefocus", uiAudio.muteFocusLost.enabled );
 }
 
 /*
@@ -126,6 +133,7 @@ static void UI_Audio_Callback( void *self, int event )
 	{
 	case ID_INTERP:
 	case ID_NODSP:
+	case ID_MUTEFOCUSLOST:
 		if( event == QM_PRESSED )
 			((menuCheckBox_s *)self)->focusPic = UI_CHECKBOX_PRESSED;
 		else ((menuCheckBox_s *)self)->focusPic = UI_CHECKBOX_FOCUS;
@@ -243,6 +251,15 @@ static void UI_Audio_Init( void )
 	uiAudio.noDSP.generic.callback = UI_Audio_Callback;
 	uiAudio.noDSP.generic.statusText = "this disables sound processing (like echo, flanger etc)";
 
+	uiAudio.muteFocusLost.generic.id = ID_MUTEFOCUSLOST;
+	uiAudio.muteFocusLost.generic.type = QMTYPE_CHECKBOX;
+	uiAudio.muteFocusLost.generic.flags = QMF_HIGHLIGHTIFFOCUS | QMF_ACT_ONRELEASE | QMF_MOUSEONLY | QMF_DROPSHADOW;
+	uiAudio.muteFocusLost.generic.name = "Mute when inactive";
+	uiAudio.muteFocusLost.generic.x = 320;
+	uiAudio.muteFocusLost.generic.y = 570;
+	uiAudio.muteFocusLost.generic.callback = UI_Audio_Callback;
+	uiAudio.muteFocusLost.generic.statusText = "silence the audio when game window loses focus";
+
 	UI_Audio_GetConfig();
 
 	UI_AddItem( &uiAudio.menu, (void *)&uiAudio.background );
@@ -253,6 +270,7 @@ static void UI_Audio_Init( void )
 	UI_AddItem( &uiAudio.menu, (void *)&uiAudio.suitVolume );
 	UI_AddItem( &uiAudio.menu, (void *)&uiAudio.lerping );
 	UI_AddItem( &uiAudio.menu, (void *)&uiAudio.noDSP );
+	UI_AddItem( &uiAudio.menu, (void *)&uiAudio.muteFocusLost );
 }
 
 /*


### PR DESCRIPTION
Original code was quite misbehaving, hijacking the mouse every time mouse was moved over the window, which isn't desired in windowed mode. Also made the game remember window position, like original Windows only version had implemented already and added a feature that mutes sound when window loses focus. It just sets volume to 0, probably not the best solution, but most bug free in the current state. Engine could use some improvements when it comes to HOST_MINIMIZED and HOST_NOFOCUS states.

"pause" command no longer crashes the engine and some unused code has been removed.