### PR TITLE
Disallow kick of local client, revert minor messup from commit 802c0ed

### DIFF
--- a/engine/client/sound.h
+++ b/engine/client/sound.h
@@ -323,6 +323,7 @@ void SND_CloseMouth( channel_t *ch );
 void S_StreamSoundTrack( void );
 void S_StreamBackgroundTrack( void );
 qboolean S_StreamGetCurrentState( char *currentTrack, char *loopTrack, int *position );
+void S_StopBackgroundTrack( void );
 void S_PrintBackgroundTrackState( void );
 void S_FadeMusicVolume( float fadePercent );
 

--- a/engine/server/sv_cmds.c
+++ b/engine/server/sv_cmds.c
@@ -109,11 +109,11 @@ qboolean SV_SetPlayer( void )
 	sv_client_t	*cl;
 	int		i, idnum;
 
-	if( !svs.clients )
+	if( !svs.clients || sv.background )
 	{
 		Msg( "^3No server running.\n" );
 		return false;
-          }
+	}
 
 	if( sv_maxclients->integer == 1 || Cmd_Argc() < 2 )
 	{
@@ -668,17 +668,17 @@ void SV_Kick_f( void )
 {
 	if( Cmd_Argc() != 2 )
 	{
-		Msg( "Usage: kick <userid>\n" );
-		return;
-	}
-
-	if( !svs.clients || sv.background )
-	{
-		Msg( "^3No server running.\n" );
+		Msg( "Usage: kick <userid> | <name>\n" );
 		return;
 	}
 
 	if( !SV_SetPlayer( )) return;
+
+	if( NET_IsLocalAddress( svs.currentPlayer->netchan.remote_address ))
+	{
+		Msg( "The local player cannot be kicked!\n" );
+		return;
+	}
 
 	SV_BroadcastPrintf( PRINT_HIGH, "%s was kicked\n", svs.currentPlayer->name );
 	SV_ClientPrintf( svs.currentPlayer, PRINT_HIGH, "You were kicked from the game\n" );

--- a/engine/server/sv_save.c
+++ b/engine/server/sv_save.c
@@ -2132,6 +2132,7 @@ qboolean SV_LoadGame( const char *pName )
 	sv.background = false;
 
 	SCR_BeginLoadingPlaque ( false );
+	S_StopBackgroundTrack();
 
 	MsgDev( D_INFO, "Loading game from %s...\n", name );
 	SV_ClearSaveDir();


### PR DESCRIPTION
Seems that call to S_StopBackgroundTrack is needed there otherwise music from previous map plays if newly loaded savegame doesn't specify that anything should be playing, also added declaration so compiler doesn't complain about undefined function.