### PR TITLE
Fix of pfnDrawStringReverse

### DIFF
--- a/engine/client/cl_game.c
+++ b/engine/client/cl_game.c
@@ -2831,8 +2831,10 @@ pfnDrawStringReverse
 */
 int pfnDrawStringReverse( int x, int y, const char *str, int r, int g, int b )
 {
+	char * szIt = 	str;
+	
 	// find the end of the string
-	for( char *szIt = str; *szIt != 0; szIt++ )
+	for( szIt = str; *szIt != 0; szIt++ )
 		x -= clgame.scrInfo.charWidths[ (unsigned char) *szIt ];
 	pfnDrawString( x, y, str, r, g, b );
 	return x;


### PR DESCRIPTION
A for function used a initial declaration what is enabled only in C11 or C99, so i maked declaration before for.